### PR TITLE
Fix transaction

### DIFF
--- a/python/pycrdt/transaction.py
+++ b/python/pycrdt/transaction.py
@@ -20,8 +20,8 @@ class Transaction:
     def __enter__(self) -> _Transaction:
         self._nb += 1
         if self._doc._txn is None:
-            self._doc._txn = self
             self._txn = self._doc._doc.create_transaction()
+            self._doc._txn = self
         return self._txn
 
     def __exit__(self, exc_type, exc_value, exc_tb) -> None:


### PR DESCRIPTION
If an error was raised during the creation of the (Yrs) transaction, the `Transaction` seemed to have been created anyway.