### PR TITLE
Fix typo in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ This is how a remote document will retrieve the root types of the document, afte
 from pycrdt import Doc, Text, Array, Map
 
 remote_doc = Doc()
-remote_doc.apply_updates(updates)
+remote_doc.apply_update(updates)
 
 text0 = Text()
 array0 = Array()

--- a/README.md
+++ b/README.md
@@ -65,10 +65,12 @@ When they got inserted into `doc`, we gave them a name. For instance, `text0` wa
 This is how a remote document will retrieve the root types of the document, after applying the received updates:
 
 ```py
-from pycrdt import Doc, Text, Array, Map
+update = doc.get_update()
+
+# the (binary) update could travel on the wire to a remote machine
 
 remote_doc = Doc()
-remote_doc.apply_update(updates)
+remote_doc.apply_update(update)
 
 text0 = Text()
 array0 = Array()


### PR DESCRIPTION
Just noticed this typo, but I wonder if we should also show what updates is? (I'm trying to figure out that now)