### PR TITLE
Allow passing model for document update validation

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -156,13 +156,13 @@ Unregistering the callback is done with the same `unobserve` method.
 ### Document events
 
 Observing changes made to a document is mostly meant to send the changes to another document, usually over the wire to a remote machine.
-Changes can be serialized to binary by calling `get_update()` on the event:
+Changes can be serialized to binary by getting the event's `update`:
 
 ```py
 from pycrdt import TransactionEvent
 
 def handle_doc_changes(event: TransactionEvent):
-    update: bytes = event.get_update()
+    update: bytes = event.update
     # send binary update on the wire
 
 doc.observe(handle_doc_changes)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
     "Programming Language :: Rust",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
@@ -30,9 +31,10 @@ classifiers = [
 
 [project.optional-dependencies]
 test = [
-  "pytest >=7.4.2,<8",
-  "y-py >=0.7.0a1,<0.8",
-  "mypy",
+    "pytest >=7.4.2,<8",
+    "y-py >=0.7.0a1,<0.8",
+    "pydantic >=2.5.2,<3",
+    "mypy",
 ]
 docs = [ "mkdocs", "mkdocs-material" ]
 

--- a/python/pycrdt/map.py
+++ b/python/pycrdt/map.py
@@ -64,6 +64,11 @@ class Map(BaseType):
         with self.doc.transaction() as txn:
             return self.integrated.to_json(txn._txn)
 
+    def to_py(self) -> dict | None:
+        if self._integrated is None:
+            return self._prelim
+        return dict(self)
+
     def __delitem__(self, key: str) -> None:
         if not isinstance(key, str):
             raise RuntimeError("Key must be of type string")
@@ -147,7 +152,9 @@ class Map(BaseType):
 
 def observe_callback(callback: Callable[[Any], None], doc: Doc, event: Any):
     _event = event_types[type(event)](event, doc)
+    doc._txn = ReadTransaction(doc=doc, _txn=event.transaction)
     callback(_event)
+    doc._txn = None
 
 
 def observe_deep_callback(callback: Callable[[Any], None], doc: Doc, events: list[Any]):

--- a/python/pycrdt/transaction.py
+++ b/python/pycrdt/transaction.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from types import TracebackType
 from typing import TYPE_CHECKING
 
 from ._pycrdt import Transaction as _Transaction
@@ -25,7 +26,12 @@ class Transaction:
         self._doc._txn = self
         return self
 
-    def __exit__(self, exc_type, exc_value, exc_tb) -> None:
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_val: BaseException | None,
+        exc_tb: TracebackType | None,
+    ) -> None:
         self._nb -= 1
         # only drop the transaction when exiting root context manager
         # since nested transactions reuse the root transaction

--- a/tests/test_doc.py
+++ b/tests/test_doc.py
@@ -86,8 +86,7 @@ def test_transaction_event():
 
     remote_doc = Doc()
     for event in events:
-        update = event.get_update()
-        remote_doc.apply_update(update)
+        remote_doc.apply_update(event.update)
 
     remote_text = Text()
     remote_doc["text"] = remote_text

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,55 @@
+from datetime import datetime
+from typing import Tuple
+
+import pytest
+from pycrdt import Array, Doc, Text
+from pydantic import BaseModel
+from pydantic import ValidationError
+
+
+def test_model():
+    remote_doc = Doc(
+        {
+            "timestamp": Text("2020-01-02T03:04:05Z"),
+            "dimensions": Array(["10", "20"]),
+        }
+    )
+    update = remote_doc.get_update()
+
+    class Delivery(BaseModel):
+        timestamp: datetime
+        dimensions: Tuple[int, int]
+
+    local_doc = Doc(
+        {
+            "timestamp": Text(),
+            "dimensions": Array(),
+        },
+        Model=Delivery,
+    )
+    local_doc.apply_update(update)
+
+    remote_doc["dimensions"][1] = "a"  # "a" is not an int
+    update = remote_doc.get_update()
+    with pytest.raises(ValidationError) as exc_info:
+        local_doc.apply_update(update)
+    assert str(exc_info.value).startswith("1 validation error for Delivery\ndimensions.1\n")
+
+    remote_doc["timestamp"][6] = "0"  # invalid "00" month
+    update = remote_doc.get_update()
+    with pytest.raises(ValidationError) as exc_info:
+        local_doc.apply_update(update)
+    assert str(exc_info.value).startswith("2 validation errors for Delivery\n")
+
+    remote_doc["dimensions"][1] = "30"  # revert invalid change, and make a change
+    update = remote_doc.get_update()
+    with pytest.raises(ValidationError) as exc_info:
+        local_doc.apply_update(update)
+    assert str(exc_info.value).startswith("1 validation error for Delivery\ntimestamp\n")
+
+    remote_doc["timestamp"][6] = "2"  # revert invalid change, and make a change
+    update = remote_doc.get_update()
+    local_doc.apply_update(update)
+
+    assert str(local_doc["timestamp"]) == "2020-02-02T03:04:05Z"
+    assert list(local_doc["dimensions"]) == ["10", "30"]


### PR DESCRIPTION
This works by having a "twin document" for a `Doc` that has a (pydantic) model, on which incoming updates are applied. After applying the updates, the whole document is validated, and if validation fails, the updates are not applied to the "real document" (and the validation exception is raised).
This doesn't handle changed document root types, because there is currently no way to discover root types in Yrs (see https://github.com/y-crdt/y-crdt/issues/364). Also, this only handles remote changes (applied in `apply_update`), not local changes.